### PR TITLE
Tilføj anbefaling for opdeling af repository efter risiko/profil

### DIFF
--- a/docs/repo-structure-recommendation.md
+++ b/docs/repo-structure-recommendation.md
@@ -1,0 +1,43 @@
+# Forslag: opdeling af `archaic_examples`
+
+Dette repository er en blanding af mange teknologier, tidsperioder og risikoprofiler.
+
+## Hvorfor opdele?
+
+- Top-level indeholder et meget bredt miks af sprog/domæner (`c`, `java`, `python`, `perl`, `asm`, `shellscripts`, `exploits`, `misc`).
+- Root README beskriver, at meget kode er gammel (ca. 1995-2005) og kan være skadelig ved forkert brug.
+- Der ligger direkte exploit-/offensiv kode samt bevidst sårbar demo-kode i samme repo som almindelige læringseksempler.
+
+## Anbefalet målarkitektur
+
+1. `archaic-examples-safe`  
+   Klassiske læringseksempler uden aktivt skadelig adfærd.
+2. `archaic-examples-security-lab`  
+   Sårbarheds- og exploit-demokode (isoleres tydeligt med advarsler).
+3. `archaic-examples-archive`  
+   Historisk, uændret reference (read-only/arkiv).
+
+Alternativt: behold ét mono-repo, men opdel i tydelige domæner med stærke guardrails:
+
+- `safe/`
+- `security-lab/`
+- `archive/`
+
+## Praktisk migrationsplan
+
+1. Frys nuværende repo (tag fx `legacy-snapshot-YYYYMMDD`).
+2. Definér flytteregler pr. mappe (safe vs. security-lab vs. archive).
+3. Flyt i batches og bevar historik (`git filter-repo` eller `git subtree split`).
+4. Tilføj tydelige README-advarsler og kørselspolitikker i hvert nyt repo.
+5. Aktivér branch protection + CODEOWNERS pr. repo.
+6. Brug CI med minimum: lint + statisk scan + hemmeligheds-scan.
+
+## Minimum hvis I ikke splitter nu
+
+- Kræv kørsel i container/VM for alt under `exploits/` og risikable `misc/`-dele.
+- Tilføj pre-commit/CI, der blokerer nye hardcoded credentials og farlige shell-kald.
+- Indfør navngivningskonventioner (`demo-vuln-*`, `exploit-*`, `safe-*`) for tydelighed.
+
+## Kort anbefaling
+
+Ja: opdeling er fornuftig. Den bedste balance er typisk 2-3 repos efter risikoprofil og formål, så læringskode, offensiv lab-kode og historisk arkiv ikke blandes i samme samarbejdsflow.


### PR DESCRIPTION
### Motivation
- Repositoriet indeholder blandede teknologier og både ufarlige læringseksempler og bevidst sårbar/offensiv kode, hvilket øger risikoen for utilsigtet misbrug. 
- Målet er at give en klar anbefaling for at separere indhold efter formål og risikoniveau for bedre sikkerhed og vedligeholdelse.

### Description
- Tilføjer dokumentationen `docs/repo-structure-recommendation.md` med en konkret anbefaling om at splitte i `safe`, `security-lab` og `archive` eller alternativt opdele i domæner i et mono-repo. 
- Dokumentet indeholder en praktisk migrationsplan med trin til at bevare historik og sikre nye repositories samt minimums-hærdning hvis opdeling ikke gennemføres. 
- Indeholder også forslag til kørselskrav (container/VM), pre-commit/CI-scanning og navngivningskonventioner for risikofyldte filer.

### Testing
- Verificerede repositoryindhold og struktur med `rg --files -g 'AGENTS.md'` og `find . -maxdepth 2 -type d`, som lykkedes. 
- Læste relevante filer for kontekst med `nl -ba README.md | sed -n '1,120p'` og `nl -ba exploits/root.sh | sed -n '1,200p'`, som lykkedes. 
- Bekræftede indholdet af den nye dokumentationsfil med `nl -ba docs/repo-structure-recommendation.md | sed -n '1,200p'`, som lykkedes. 
- Ændringen er dokumentation-only, så der er ingen runtime-testkrav.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_688b5d345bf083318aef065ffc467f2a)