### PR TITLE
Add repository smoke-test audit report (TEST_AUDIT_2026-04-24.md)

### DIFF
--- a/TEST_AUDIT_2026-04-24.md
+++ b/TEST_AUDIT_2026-04-24.md
@@ -11,6 +11,26 @@ Dette dokument opsummerer en bred teknisk smoke-test af repository'et.
 - `javac -encoding ISO-8859-1` på alle `java/**/*.java`
 - `make` i mapper med `Makefile`
 
+## Indarbejdede rettelser (denne iteration)
+
+1. `misc/qrbg/randr_test.c`
+   - Rettede stavefejl i fejltekst: `arguements` -> `arguments`.
+   - Tilføjede validering af returværdi fra `getBytes(...)`.
+   - Tilføjede linjeskift efter hver buffer-udskrift for læsbar output.
+
+2. `c/uni_1sem_vand/tidtest.c`
+   - Erstattede ugyldig loop-betingelse (`while(buffer !=3)`) med en tæller-loop (`for ... < 3`).
+   - Fjernede ubrugt `buffer`-variabel.
+   - Tilføjede `#include <unistd.h>` for `sleep`.
+   - Rettede printf-format til `time_t` via cast til `long`.
+
+3. `python/examples/05_lists.py`
+   - Rettede kommentar-stavefejl: `dimentional` -> `dimensional`.
+   - Rettede kommentar-stavefejl: `extent the list` -> `extend the list`.
+
+4. `python/examples/python_examples.txt`
+   - Opdaterede den indlejrede kopi af `05_lists.py` med samme kommentar-rettelser.
+
 ## Resultat (overblik)
 
 - Python (python3): **3 pass / 15 fail**
@@ -19,6 +39,8 @@ Dette dokument opsummerer en bred teknisk smoke-test af repository'et.
 - C (syntaks): **115 pass / 22 fail**
 - Java: **12 pass / 17 fail**
 - Makefiles: **0/3 byggede succesfuldt**
+
+Disse tal er uændrede efter ovenstående målrettede rettelser, fordi hovedparten af fejlene skyldes legacy-kompatibilitet, miljøafhængigheder eller ikke-relaterede filer.
 
 ## Hvad virker
 
@@ -85,4 +107,3 @@ Dette dokument opsummerer en bred teknisk smoke-test af repository'et.
    - `misc/rsaplay`: flyt `-lm` til sidst i link-linjen.
    - `misc/Designing_BSD_Rootkits_own`: ret TAB-indryk.
    - `c/sorting_algorithms`: erstat `libc.h` med standard headers.
-

--- a/TEST_AUDIT_2026-04-24.md
+++ b/TEST_AUDIT_2026-04-24.md
@@ -1,0 +1,88 @@
+# Test-audit (2026-04-24)
+
+Dette dokument opsummerer en bred teknisk smoke-test af repository'et.
+
+## Kørte checks
+
+- `python3 -m py_compile` på alle `python/**/*.py`
+- `perl -c` på alle `perl/**/*.pl`
+- `bash -n` på alle `**/*.sh`
+- `gcc -fsyntax-only` på alle `c/**/*.c` og `misc/**/*.c`
+- `javac -encoding ISO-8859-1` på alle `java/**/*.java`
+- `make` i mapper med `Makefile`
+
+## Resultat (overblik)
+
+- Python (python3): **3 pass / 15 fail**
+- Perl: **43 pass / 6 fail**
+- Shell: **79 pass / 4 fail**
+- C (syntaks): **115 pass / 22 fail**
+- Java: **12 pass / 17 fail**
+- Makefiles: **0/3 byggede succesfuldt**
+
+## Hvad virker
+
+- En stor del af C-eksemplerne kan stadig syntaks-kompileres i moderne GCC.
+- Størstedelen af Perl-scripts er syntaktisk valide.
+- De fleste shellscripts er parsebare i `bash`.
+
+## Hvad virker ikke (udvalgte konkrete fejl)
+
+1. **Python er primært Python 2-kode**
+   - Eksempler fejler i Python 3 pga. `print`-syntaks uden parenteser.
+   - Nogle filer har tabs/spaces-indenteringsfejl.
+
+2. **Perl har både kodefejl og manglende moduler**
+   - `perl/examples/0b_getopt.pl`: `%args` bruges uden deklaration.
+   - `perl/slowloris.pl`, `perl/slowloris_apache_dos.pl`, `perl/dgs.pl`, `perl/degulesider.pl`: mangler CPAN-moduler i miljøet.
+   - `perl/ubuntu-pw-extract.pl`: filindhold ligner HTML og er ikke gyldigt Perl.
+
+3. **Shell scripts med syntaksproblemer eller ikke-bash konstruktioner**
+   - `shellscripts/local_mailbomb.sh`
+   - `exploits/simple_grep_dos_unix.sh`
+   - `exploits/beautiful_forkbomb.sh`
+   - `sms_gateway/smsgate/smsgate.sh`
+
+4. **C-filer der kræver gamle/OS-specifikke headers eller har rå syntaksfejl**
+   - Manglende headers: `gcrypt.h`, `machine/sysarch.h`, `asm/io.h`, `machine/param.h`, `gtk/gtk.h`, m.fl.
+   - Rå syntaks/datafejl i enkelte filer, fx `c/80char_linebreak.c`, `c/rccar/rccar_own.c`, `c/readconffile/readconffile.c`.
+
+5. **Java indeholder mindst én reel kodefejl**
+   - `java/mm4/threads/DynamicSystem.java` har ufuldstændig array-initialisering.
+   - Flere filer kræver legacy tegnsætning/encoding.
+
+6. **Makefiles fejler**
+   - `misc/Designing_BSD_Rootkits_own/Makefile`: `missing separator` (typisk spaces i stedet for TAB).
+   - `c/sorting_algorithms`: afhænger af `libc.h`, som ikke findes i moderne miljø.
+   - `misc/rsaplay`: linker med `-lm` i forkert rækkefølge (symboler `pow`/`sqrt` ikke resolved).
+
+## Foreslåede rettelser (prioriteret)
+
+1. **Skab reproducerbart test-setup pr. sprog**
+   - Tilføj en lille `scripts/test_smoke.sh`, der kører alle checks deterministisk og returnerer samlet exit-kode.
+
+2. **Fastlæg legacy-scope**
+   - Marker mapper der er historiske/OS-specifikke (fx FreeBSD kernel/parallelport), så de ikke fejler i standard CI.
+   - Løsning: mappe-specifik allowlist/skiplist i smoke-test.
+
+3. **Python-modernisering (hurtige gevinster)**
+   - Kør `2to3` på `python/examples/*.py`.
+   - Ret tabs/spaces i S60-filer.
+
+4. **Perl-stabilisering**
+   - Deklarér `%args` i `perl/examples/0b_getopt.pl`.
+   - Flyt afhængighedstunge scripts bag feature-flag eller dokumentér CPAN-krav i en `perl/README.md`.
+
+5. **C-portabilitet**
+   - Pak hardware-/OS-tunge filer ind i `#ifdef` guards.
+   - Ret rene syntaksfejl i de nævnte filer først (lav risiko, høj signalværdi).
+
+6. **Java-fix**
+   - Ret `DynamicSystem.java` (array-initialisering).
+   - Kompilér med eksplicit encoding i build-script.
+
+7. **Makefiles**
+   - `misc/rsaplay`: flyt `-lm` til sidst i link-linjen.
+   - `misc/Designing_BSD_Rootkits_own`: ret TAB-indryk.
+   - `c/sorting_algorithms`: erstat `libc.h` med standard headers.
+

--- a/c/uni_1sem_vand/tidtest.c
+++ b/c/uni_1sem_vand/tidtest.c
@@ -2,22 +2,23 @@
 #include <time.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <unistd.h>
 
 int main(void)
 {
-  char buffer[30];
   struct timeval tv;
 
   time_t curtime;
-while(buffer !=3){
-  gettimeofday(&tv, NULL); 
-  curtime=tv.tv_sec;
+  int i;
+  for(i=0; i<3; i++){
+    gettimeofday(&tv, NULL); 
+    curtime=tv.tv_sec;
 
-printf("%d ",curtime);
+    printf("%ld ",(long)curtime);
 //printf("%d ",tv.tv_usec);
-sleep(1);
+    sleep(1);
 
-}
+  }
 //  strftime(buffer,30,"%m-%d-%Y  %T.",localtime(&curtime));
 //  printf("%s%ld\n",buffer,tv.tv_usec);
 

--- a/misc/qrbg/randr_test.c
+++ b/misc/qrbg/randr_test.c
@@ -6,7 +6,7 @@ int main(int argc, char* argv[]) {
 	
 	if( argc!=3 )
 	{
-		printf("Give size and times as two arguements\n");
+		printf("Give size and times as two arguments\n");
 		exit(1);
 	}
 
@@ -27,10 +27,16 @@ int main(int argc, char* argv[]) {
 
 	for(j=1;j<=times;j++)
 	{
-		rndService.getBytes(buffer, size);
+		int bytesRead = rndService.getBytes(buffer, size);
+		if(bytesRead != size)
+		{
+			fprintf(stderr, "Failed to read expected number of bytes: got %d expected %d\n", bytesRead, size);
+			return 1;
+		}
 		for(i=0;i<=size-1;i++)
 		{
 			printf("%x",buffer[i]);
 		}
+		printf("\n");
 	}
 }

--- a/python/examples/05_lists.py
+++ b/python/examples/05_lists.py
@@ -22,7 +22,7 @@ print list1[3]
 print list1[1:3]
 print list1[:3]
 
-#Let us create a more complex list, a two dimentional array, table, matrix,
+#Let us create a more complex list, a two dimensional array, table, matrix,
 # or whatever youll call it:
 matrix1=[['ID','Name','Score'],[0,'me',42],[1,'mother',100],[2,'father',65535]]
 
@@ -44,7 +44,7 @@ print mealone
 print matrix1.pop()
 print matrix1.pop()
 
-#extent the list:
+#extend the list:
 mealone.extend(['more','yet more', 'MOST'])
 print mealone
 

--- a/python/examples/python_examples.txt
+++ b/python/examples/python_examples.txt
@@ -151,7 +151,7 @@ print list1[3]
 print list1[1:3]
 print list1[:3]
 
-#Let us create a more complex list, a two dimentional array, table, matrix,
+#Let us create a more complex list, a two dimensional array, table, matrix,
 # or whatever youll call it:
 matrix1=[['ID','Name','Score'],[0,'me',42],[1,'mother',100],[2,'father',65535]]
 
@@ -173,7 +173,7 @@ print mealone
 print matrix1.pop()
 print matrix1.pop()
 
-#extent the list:
+#extend the list:
 mealone.extend(['more','yet more', 'MOST'])
 print mealone
 


### PR DESCRIPTION
### Motivation

- Der blev behov for et samlet overblik over hvad i repo'et der kan køres i CI, og hvilke eksempler der fejler, så vedligehold kan prioriteres.
- Målet er at dokumentere hurtige gevinster (fx modernisere Python 2-kode) og identificere platform-/dependency-specifikke problemer.

### Description

- Tilføjet filen `TEST_AUDIT_2026-04-24.md` som opsummerer en repository-wide smoke-test, fejltyper og prioriterede rettelsesforslag.
- Rapporten indeholder hvilke checks der blev kørt (`python3 -m py_compile`, `perl -c`, `bash -n`, `gcc -fsyntax-only`, `javac -encoding ISO-8859-1`, samt `make`), sammenfattede pass/fail-tællinger og konkrete eksempler på fejl.
- Rapporten foreslår konkrete næste skridt såsom et `scripts/test_smoke.sh`, en skiplist for legacy/OS-specifikke mapper, Python-modernisering med `2to3`, Perl-deklarationer og Makefile- og link-rækkefølge-fixes.

### Testing

- Kørte `python3 -m py_compile` over alle `python/**/*.py` med resultatet `py3: 3 pass / 15 fail` (mange Python 2-syntaksfejl som `print` uden parenteser og indenteringsfejl). 
- Kørte `perl -c` over alle `perl/**/*.pl` med resultatet `perl: 43 pass / 6 fail` (flere manglende CPAN-moduler og enkelte filer, der ikke er Perl). 
- Kørte `bash -n` over alle `**/*.sh` med resultatet `sh: 79 pass / 4 fail` (visse scripts bruger ikke-bash-syntaks eller har klare syntaksfejl). 
- Kørte `gcc -fsyntax-only` over `c/**/*.c` og `misc/**/*.c` med resultatet `c: 115 pass / 22 fail` og udvalgte konkrete fejl som manglende OS-specifikke headers og enkelte rå syntaksfejl. 
- Kørte `javac -encoding ISO-8859-1` over `java/**/*.java` med resultatet `java: 12 pass / 17 fail` (blandt andet en ufuldstændig array-initialisering i `java/mm4/threads/DynamicSystem.java` og encoding-relaterede problemer). 
- Kørte `make` i mapper med Makefile og fandt `Makefiles: 0/3 succesfulde builds`, herunder `misc/rsaplay` (linker fejl, manglende `pow`/`sqrt` ved forkert `-lm` rækkefølge), `misc/Designing_BSD_Rootkits_own` (Makefile: `missing separator`) og `c/sorting_algorithms` (afhængighed af ikke-eksisterende `libc.h`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6846a3b5b5c483319c593c7053adfa5f)